### PR TITLE
Deprecate `master` branch in favor of `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,31 @@
- [![Code of Conduct](https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg?style=flat)](https://github.com/edgi-govdata-archiving/overview/blob/master/CONDUCT.md)
+# **IMPORTANT! We've moved development of this repo to the `main` branch. You will not be able to merge changes into `master`.**
+
+## **UPDATING LOCAL CLONES**
+
+(via [this link](https://www.hanselman.com/blog/EasilyRenameYourGitDefaultBranchFromMasterToMain.aspx), thanks!)
+
+If you have a local clone, you can update and change your default branch with the steps below.
+
+```sh
+git checkout master
+git branch -m master main
+git fetch
+git branch --unset-upstream
+git branch -u origin/main
+git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
+```
+
+The above steps accomplish:
+
+1. Go to the master branch
+2. Rename master to main locally
+3. Get the latest commits from the server
+4. Remove the link to origin/master
+5. Add a link to origin/main
+6. Update the default branch to be origin/main
+
+
+[![Code of Conduct](https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg?style=flat)](https://github.com/edgi-govdata-archiving/overview/blob/master/CONDUCT.md)
 
 # ECHO-Cross-Programs
 This repository contains Jupyter notebooks for ECHO that use data from multiple


### PR DESCRIPTION
This adds a deprecation notice to the README on the `master` branch and is part of edgi-govdata-archiving/overview#243. Once this is approved, I’m happy to also add the `main` branch and change the default branch settings if nobody else is able to.

@ericnost @shansen5 I’m not highly involved in this repo, so won’t make any changes without sign-off here from one of you.